### PR TITLE
Modify (p)arpack fail logic

### DIFF
--- a/src/SF_SP_LINALG/arpack_c.f90
+++ b/src/SF_SP_LINALG/arpack_c.f90
@@ -131,10 +131,11 @@ subroutine lanczos_arpack_c(MatVec,eval,evec,Nblock,Nitermax,bmat,v0,tol,iverbos
   end do
   !
   !POST PROCESSING:
-  if(info/=0)then
-     write(*,'(a,i6)')'Warning/Error in ZNAUPD, info = ', info
-     include "error_msg_arpack.h90"
-  else
+  if(info>=0)then
+     if (info > 0)then
+        write(*,'(a,i6)')'Soft failure in ZNAUPD, info = ',info
+        include "error_msg_arpack.h90"
+     endif
      rvec = .true.
      call zneupd  (rvec,'A',select,d,v,ldv,sigma,workev,bmat_,n,which_,&
           nev,tol_,resid,ncv,v,ldv,iparam,ipntr,workd,workl,lworkl,rwork,ierr)
@@ -166,6 +167,10 @@ subroutine lanczos_arpack_c(MatVec,eval,evec,Nblock,Nitermax,bmat,v0,tol,iverbos
      !
      !if(nconv == 0) stop "ARPACK:: no converged eigenvalues have been found."
      !
+  else
+    write(*,'(a,i6)')'Hard failure in ZNAUPD, info = ',info
+    include "error_msg_arpack.h90"
+    STOP
   endif
   deallocate(ax,d,resid,v,workd,workev,workl,rwork,rd,select)
   !

--- a/src/SF_SP_LINALG/arpack_d.f90
+++ b/src/SF_SP_LINALG/arpack_d.f90
@@ -127,10 +127,11 @@ subroutine lanczos_arpack_d(MatVec,eval,evec,Nblock,Nitermax,bmat,v0,tol,iverbos
   !
   !
   !POST PROCESSING:
-  if(info/=0)then
-     write(*,'(a,i6)')'Warning/Error in DSAUPD, info = ', info
-     include "error_msg_arpack.h90"
-  else
+  if(info>=0)then
+     if (info > 0)then
+        write(*,'(a,i6)')'Soft failure in DSAUPD, info = ',info
+        include "error_msg_arpack.h90"
+     endif     
      rvec = .true.
      call dseupd(rvec,'All',select,d,v,ldv,sigma,bmat_,n,which_,&
           nev,tol_,resid,ncv,v,ldv,iparam,ipntr,workd,workl,lworkl,ierr)
@@ -155,6 +156,9 @@ subroutine lanczos_arpack_d(MatVec,eval,evec,Nblock,Nitermax,bmat,v0,tol,iverbos
      !
      !if(nconv == 0) stop "ARPACK:: no converged eigenvalues have been found."
      !
+  else
+    write(*,'(a,i6)')'Hard failure in DSAUPD, info = ',info
+    include "error_msg_arpack.h90"
   endif
   deallocate(ax,d,resid,workl,workd,v,select)
 end subroutine lanczos_arpack_d

--- a/src/SF_SP_LINALG/parpack_c.f90
+++ b/src/SF_SP_LINALG/parpack_c.f90
@@ -174,12 +174,11 @@ subroutine lanczos_parpack_c(MpiComm,MatVec,eval,evec,Nblock,Nitermax,v0,tol,ive
   end do
   !
   !POST PROCESSING:
-  if(info/=0)then
-     if(mpi_master)then
-        write(*,'(a,i6)')'Warning/Error in PZNAUPD, info = ', info
+  if(info>=0)then
+     if (info > 0 .and. mpi_master)then
+        write(*,'(a,i6)')'Soft failure in PZNAUPD, info = ',info
         include "error_msg_arpack.h90"
      endif
-  else
      !
      call pzneupd (MpiComm,.true.,'All',select,d,v,ldv,sigma,workev,bmat,&
           ldv,which_,nev,tol_,resid,ncv,v,ldv,iparam,ipntr,workd,workl,lworkl,rwork,ierr)
@@ -212,6 +211,10 @@ subroutine lanczos_parpack_c(MpiComm,MatVec,eval,evec,Nblock,Nitermax,v0,tol,ive
      !
      !
      ! if(mpi_master.and.nconv==0.and.verb)stop "None of the required values was found."
+  else
+    write(*,'(a,i6)')'Hard failure in PZNAUPD, info = ',info
+    include "error_msg_arpack.h90"
+    STOP
   endif
   deallocate(ax,d,resid,v,workd,workev,workl,rwork,rd,select)
   !

--- a/src/SF_SP_LINALG/parpack_d.f90
+++ b/src/SF_SP_LINALG/parpack_d.f90
@@ -165,12 +165,11 @@ subroutine lanczos_parpack_d(MpiComm,MatVec,eval,evec,Nblock,Nitermax,v0,tol,ive
   end do
   !
   !POST PROCESSING:
-  if(info/=0)then
-     if(mpi_master)then
-        write(*,'(a,i6)')'Warning/Error in PDSAUPD, info = ', info
+  if(info>=0)then
+     if (info > 0 .and. mpi_master)then
+        write(*,'(a,i6)')'Soft failure in PDSAUPD, info = ',info
         include "error_msg_arpack.h90"
      endif
-  else
      !
      call pdseupd (MpiComm,.true.,'All',select,d,v,ldv,sigma,bmat,&
           ldv,which_,nev,tol_,resid,ncv,v,ldv,iparam,ipntr,workd,workl,lworkl,ierr)        
@@ -200,6 +199,10 @@ subroutine lanczos_parpack_d(MpiComm,MatVec,eval,evec,Nblock,Nitermax,v0,tol,ive
      endif
      !
      ! if(mpi_master.and.nconv==0.and.verb)stop "None of the required values was found."
+  else
+    write(*,'(a,i6)')'Hard failure in PDSAUPD, info = ',info
+    include "error_msg_arpack.h90"
+    STOP
   endif
   deallocate(ax,resid,workd,v,d,workl,select)
 end subroutine lanczos_parpack_d


### PR DESCRIPTION
As of now, if info /= 0 the postprocessing routine is never called. This results in a situation where spectra are not calculated at all but the code doesn't stop. In e.g. a Fock space sector solution, this results in some sectors having all 0 eigenvalues.

If info >0 this is a soft fail. Usually, the postprocessing routine can still be called but the spectrum will not be precise. It is probably better than nothing and certainly better than having all zeros.

This commit prints a message in case of soft fail, but still calls the postprocessing routine. If info < 0 that is a hard fail, and the program stops.